### PR TITLE
feat: Re-enable Facebook Ads tool and block with dynamic date extraction

### DIFF
--- a/apps/sim/app/api/facebook-ads/query/ai-query-generation.ts
+++ b/apps/sim/app/api/facebook-ads/query/ai-query-generation.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@/lib/logs/console/logger'
 import { executeProviderRequest } from '@/providers'
 import { getApiKey } from '@/providers/utils'
 import { DEFAULT_DATE_PRESET, DEFAULT_FIELDS } from './constants'
+import { extractFacebookDateSelection } from './date-extraction'
 import { detectIntents } from './intent-detector'
 import { buildSystemPrompt } from './prompt-fragments'
 import type { ParsedFacebookQuery } from './types'
@@ -17,9 +18,13 @@ export async function parseQueryWithAI(
   // Step 1: Detect query intents
   const { intents, promptContext } = detectIntents(userQuery)
 
+  // Step 1b: Detect any explicit date range or preset mentioned by the user
+  const detectedDateSelection = extractFacebookDateSelection(userQuery)
+
   logger.info('Detected query intents', {
     intents,
     userQuery,
+    detectedDateSelection,
   })
 
   // Step 2: Build dynamic system prompt based on intents
@@ -232,11 +237,23 @@ Always return valid JSON. Never refuse to generate a response.`
       level,
     })
 
+    // Merge AI date selection with our deterministic extractor
+    let datePreset = parsedResponse.date_preset as string | undefined
+    let timeRange = parsedResponse.time_range as
+      | { since: string; until: string }
+      | undefined
+
+    // If the model did not specify any date, fall back to detected natural language ranges
+    if (!datePreset && !timeRange && detectedDateSelection) {
+      datePreset = detectedDateSelection.date_preset
+      timeRange = detectedDateSelection.time_range
+    }
+
     return {
       endpoint,
       fields,
-      date_preset: parsedResponse.date_preset || DEFAULT_DATE_PRESET,
-      time_range: parsedResponse.time_range,
+      date_preset: datePreset || DEFAULT_DATE_PRESET,
+      time_range: timeRange,
       level,
       filters: parsedResponse.filters,
       breakdowns: parsedResponse.breakdowns,

--- a/apps/sim/app/api/facebook-ads/query/date-extraction.ts
+++ b/apps/sim/app/api/facebook-ads/query/date-extraction.ts
@@ -1,0 +1,100 @@
+import { createLogger } from '@/lib/logs/console/logger'
+
+const logger = createLogger('FacebookDateExtraction')
+
+export interface FacebookTimeRange {
+  since: string
+  until: string
+}
+
+export interface FacebookDateSelection {
+  date_preset?: string
+  time_range?: FacebookTimeRange
+}
+
+function formatDate(d: Date): string {
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildLastNDaysRange(days: number): FacebookTimeRange {
+  const today = new Date()
+  const until = new Date(today)
+  const since = new Date(today)
+  // inclusive range: N days ending today
+  since.setDate(today.getDate() - (days - 1))
+  return {
+    since: formatDate(since),
+    until: formatDate(until),
+  }
+}
+
+export function extractFacebookDateSelection(input: string): FacebookDateSelection | null {
+  const lower = input.toLowerCase()
+
+  // Explicit presets first
+  if (/(^|\b)today(\b|$)/.test(lower)) {
+    logger.info('Detected date preset: today')
+    return { date_preset: 'today' }
+  }
+
+  if (/(^|\b)yesterday(\b|$)/.test(lower)) {
+    logger.info('Detected date preset: yesterday')
+    return { date_preset: 'yesterday' }
+  }
+
+  if (/\bthis month\b|\bcurrent month\b/.test(lower)) {
+    logger.info('Detected date preset: this_month')
+    return { date_preset: 'this_month' }
+  }
+
+  if (/\blast month\b/.test(lower)) {
+    logger.info('Detected date preset: last_month')
+    return { date_preset: 'last_month' }
+  }
+
+  // "last N days" patterns
+  const lastNDaysMatch = lower.match(/last\s+(\d+)\s+days?/)
+  if (lastNDaysMatch) {
+    const days = parseInt(lastNDaysMatch[1], 10)
+    if (Number.isFinite(days) && days > 0 && days <= 365) {
+      // Map to Facebook presets when possible
+      const presetMap: Record<number, string> = {
+        3: 'last_3d',
+        7: 'last_7d',
+        14: 'last_14d',
+        28: 'last_28d',
+        30: 'last_30d',
+        90: 'last_90d',
+      }
+      const preset = presetMap[days]
+      if (preset) {
+        logger.info('Detected date preset from "last N days"', { days, preset })
+        return { date_preset: preset }
+      }
+
+      // For non-standard values (e.g. 12, 15), build a custom time_range
+      const range = buildLastNDaysRange(days)
+      logger.info('Detected custom time_range from "last N days"', { days, range })
+      return { time_range: range }
+    }
+  }
+
+  // ISO single date: YYYY-MM-DD
+  const isoDateMatch = lower.match(/(20\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])/)
+  if (isoDateMatch) {
+    const [full] = isoDateMatch
+    logger.info('Detected explicit ISO date', { date: full })
+    return {
+      time_range: {
+        since: full,
+        until: full,
+      },
+    }
+  }
+
+  // If nothing matched, return null and let DEFAULT_DATE_PRESET apply (last_30d)
+  return null
+}

--- a/apps/sim/blocks/registry.ts
+++ b/apps/sim/blocks/registry.ts
@@ -15,7 +15,7 @@ import { DiscordBlock } from '@/blocks/blocks/discord'
 import { ElevenLabsBlock } from '@/blocks/blocks/elevenlabs'
 import { EvaluatorBlock } from '@/blocks/blocks/evaluator'
 import { ExaBlock } from '@/blocks/blocks/exa'
-// import { FacebookAdsBlock } from '@/blocks/blocks/facebook_ads' // TODO: Enable after testing
+import { FacebookAdsBlock } from '@/blocks/blocks/facebook_ads'
 import { FigmaBlock } from '@/blocks/blocks/figma'
 import { FileBlock } from '@/blocks/blocks/file'
 import { FirecrawlBlock } from '@/blocks/blocks/firecrawl'
@@ -99,7 +99,7 @@ export const registry: Record<string, BlockConfig> = {
   elevenlabs: ElevenLabsBlock,
   evaluator: EvaluatorBlock,
   exa: ExaBlock,
-  // facebook_ads: FacebookAdsBlock, // TODO: Enable after testing
+  facebook_ads: FacebookAdsBlock,
   figma: FigmaBlock,
   firecrawl: FirecrawlBlock,
   file: FileBlock,

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -23,7 +23,7 @@ import {
   exaResearchTool,
   exaSearchTool,
 } from '@/tools/exa'
-// import { facebookAdsQueryTool } from '@/tools/facebook_ads' // TODO: Enable after testing
+import { facebookAdsQueryTool } from '@/tools/facebook_ads'
 import {
   figmaConvertTool,
   figmaCreateStylesVariablesTool,
@@ -308,7 +308,7 @@ export const tools: Record<string, ToolConfig> = {
   google_sheets_write: googleSheetsWriteTool,
   google_sheets_update: googleSheetsUpdateTool,
   google_sheets_append: googleSheetsAppendTool,
-  // facebook_ads_query: facebookAdsQueryTool, // TODO: Enable after testing
+  facebook_ads_query: facebookAdsQueryTool,
   google_ads_query: googleAdsQueryTool,
   perplexity_chat: perplexityChatTool,
   confluence_retrieve: confluenceRetrieveTool,


### PR DESCRIPTION
- Uncommented Facebook Ads tool import and registration in tools/registry.ts
- Uncommented Facebook Ads block import and registration in blocks/registry.ts
- Added date-extraction.ts for natural language date parsing (last N days, presets, ISO dates)
- Integrated date extraction into ai-query-generation.ts with fallback to last_30d default

## Summary
Brief description of what this PR does and why.

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
