### PR TITLE
feat: add numeric ID support to old Google Ads API

### DIFF
--- a/apps/sim/blocks/blocks/google_ads.ts
+++ b/apps/sim/blocks/blocks/google_ads.ts
@@ -73,7 +73,7 @@ export const GoogleAdsBlock: BlockConfig<GoogleAdsResponse> = {
       title: 'Google Ads Account',
       type: 'short-input',
       canonicalParamId: 'accounts',
-      placeholder: 'Enter account key (e.g., ami, heartland)',
+      placeholder: 'Enter account key (e.g., ami, heartland) or numeric ID',
       required: true,
       mode: 'advanced',
     },


### PR DESCRIPTION
- Add resolveAccountKey function to /api/google-ads/query
- Support both account keys and numeric IDs in old Google Ads block
- Update placeholder text to mention numeric ID support
- Maintain consistency with Google Ads V1 API behavior

Now both old and new Google Ads blocks support:
- Account keys: ami, heartland, gentle_dental
- Numeric IDs: 1234567890, 9876543210, etc.

## Summary
Brief description of what this PR does and why.

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
