### PR TITLE
mothership chat path functionality and /hub/nome arena

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-session-event.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-session-event.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MothershipStreamV1SessionKind } from '@/lib/copilot/generated/mothership-stream-v1'
+import type { PersistedStreamEventEnvelope } from '@/lib/copilot/request/session/contract'
+import type { StreamLoopContext } from '@/app/workspace/[workspaceId]/home/hooks/stream/stream-context'
+import { handleSessionEvent } from '@/app/workspace/[workspaceId]/home/hooks/stream/handle-session-event'
+
+function makeSessionEvent(chatId: string): Extract<PersistedStreamEventEnvelope, { type: 'session' }> {
+  return {
+    type: 'session',
+    payload: { kind: MothershipStreamV1SessionKind.chat, chatId },
+    seq: 1,
+    stream: { streamId: 'stream-1' },
+    ts: '2026-01-01T00:00:00Z',
+    v: 1,
+  } as Extract<PersistedStreamEventEnvelope, { type: 'session' }>
+}
+
+function makeCtx(isEmbedPage: boolean): StreamLoopContext {
+  const chatIdRef = { current: undefined as string | undefined }
+  const selectedChatIdRef = { current: undefined as string | undefined }
+  const workflowIdRef = { current: undefined as string | undefined }
+  const isEmbedPageRef = { current: isEmbedPage }
+
+  return {
+    state: {} as StreamLoopContext['state'],
+    ops: {} as StreamLoopContext['ops'],
+    deps: {
+      workspaceId: 'ws-1',
+      chatIdRef,
+      selectedChatIdRef,
+      workflowIdRef,
+      isEmbedPageRef,
+      setResolvedChatId: vi.fn(),
+      queryClient: { invalidateQueries: vi.fn() },
+      pendingUserMsgRef: { current: null },
+      streamIdRef: { current: undefined },
+      activeTurnRef: { current: null },
+      streamingContentRef: { current: '' },
+      streamingBlocksRef: { current: [] },
+      resourcesRef: { current: [] },
+      setPendingMessages: vi.fn(),
+      buildAssistantSnapshotMessage: vi.fn(),
+      queryClient_setQueryData: vi.fn(),
+    } as unknown as StreamLoopContext['deps'],
+  }
+}
+
+describe('handleSessionEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    window.history.replaceState({}, '', '/workspace/ws-1/home/embed?role=exec')
+  })
+
+  it('keeps embed chats on the task embed route', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState')
+    const ctx = makeCtx(true)
+
+    handleSessionEvent(ctx, makeSessionEvent('chat-1'))
+
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      '',
+      '/workspace/ws-1/task/chat-1/embed?role=exec'
+    )
+  })
+
+  it('uses the standard chat route outside embed', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState')
+    const ctx = makeCtx(false)
+
+    handleSessionEvent(ctx, makeSessionEvent('chat-1'))
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/workspace/ws-1/chat/chat-1?role=exec')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-session-event.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-session-event.ts
@@ -2,6 +2,10 @@ import { getLiveAssistantMessageId } from '@/lib/copilot/chat/effective-transcri
 import { MothershipStreamV1SessionKind } from '@/lib/copilot/generated/mothership-stream-v1'
 import type { PersistedStreamEventEnvelope } from '@/lib/copilot/request/session/contract'
 import type { StreamLoopContext } from '@/app/workspace/[workspaceId]/home/hooks/stream/stream-context'
+import {
+  getMothershipChatPath,
+  readMothershipChatSearch,
+} from '@/app/workspace/[workspaceId]/home/mothership-chat-path'
 import { type MothershipChatHistory, mothershipChatKeys } from '@/hooks/queries/mothership-chats'
 
 type SessionEvent = Extract<PersistedStreamEventEnvelope, { type: 'session' }>
@@ -53,10 +57,14 @@ export function handleSessionEvent(ctx: StreamLoopContext, parsed: SessionEvent)
       }
       deps.setPendingMessages([])
       if (!deps.workflowIdRef.current) {
+        // Embed stays on /task/:id/embed so workspace chrome keeps the sidebar hidden.
         window.history.replaceState(
           null,
           '',
-          `/workspace/${deps.workspaceId}/chat/${payloadChatId}`
+          getMothershipChatPath(deps.workspaceId, payloadChatId, {
+            embed: deps.isEmbedPageRef.current,
+            search: readMothershipChatSearch(),
+          })
         )
       }
     }

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/stream-context.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/stream-context.ts
@@ -115,6 +115,8 @@ export interface StreamLoopDeps {
   activeTurnRef: MutableRefObject<ActiveTurn | null>
   resourcesRef: MutableRefObject<MothershipResource[]>
   workflowIdRef: MutableRefObject<string | undefined>
+  /** True when the chat surface is an embed route (no workspace sidebar). */
+  isEmbedPageRef: MutableRefObject<boolean>
   activeResourceIdRef: MutableRefObject<string | null>
   onTitleUpdateRef: MutableRefObject<(() => void) | undefined>
   onToolResultRef: MutableRefObject<

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-chat.ts
@@ -66,6 +66,10 @@ import { isWorkflowToolName } from '@/lib/copilot/tools/workflow-tools'
 import { getQueryClient } from '@/app/_shell/providers/get-query-client'
 import { useFilePreviewController } from '@/app/workspace/[workspaceId]/home/hooks/preview'
 import {
+  getMothershipChatPath,
+  readMothershipChatSearch,
+} from '@/app/workspace/[workspaceId]/home/mothership-chat-path'
+import {
   applyTurnTerminal,
   createStreamLoopContext,
   dispatchStreamEvent,
@@ -1465,7 +1469,15 @@ export function useChat(
         !workflowIdRef.current &&
         typeof window !== 'undefined'
       ) {
-        window.history.replaceState(null, '', `/workspace/${workspaceId}/chat/${chatId}`)
+        // Embed → /task/:id/embed; home → /chat/:id (see getMothershipChatPath).
+        window.history.replaceState(
+          null,
+          '',
+          getMothershipChatPath(workspaceId, chatId, {
+            embed: effectiveIsEmbedPageRef.current,
+            search: readMothershipChatSearch(),
+          })
+        )
       }
       if (options?.invalidateList) {
         queryClient.invalidateQueries({ queryKey: mothershipChatKeys.list(workspaceId) })
@@ -1983,6 +1995,8 @@ export function useChat(
         activeTurnRef,
         resourcesRef,
         workflowIdRef,
+        // Passed into handleSessionEvent for embed-aware URL updates on new chats.
+        isEmbedPageRef: effectiveIsEmbedPageRef,
         activeResourceIdRef,
         onTitleUpdateRef,
         onToolResultRef,
@@ -3315,12 +3329,12 @@ export function useChat(
                 const createChatData = await createChatResponse.json()
                 if (typeof createChatData.id === 'string' && createChatData.id.length > 0) {
                   requestChatId = createChatData.id
-                  chatIdRef.current = createChatData.id
-                  setResolvedChatId(createChatData.id)
-                  applyOptimisticSend()
-                  queryClient.invalidateQueries({
-                    queryKey: taskKeys.list(workspaceId),
+                  // Adopt chat id + embed URL before the workflow execution stream starts.
+                  adoptResolvedChatId(createChatData.id, {
+                    replaceHomeHistory: true,
+                    invalidateList: true,
                   })
+                  applyOptimisticSend()
                 }
               }
             } catch (error) {

--- a/apps/sim/app/workspace/[workspaceId]/home/mothership-chat-path.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/mothership-chat-path.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { getMothershipChatPath } from '@/app/workspace/[workspaceId]/home/mothership-chat-path'
+
+describe('getMothershipChatPath', () => {
+  it('returns the standard chat route by default', () => {
+    expect(getMothershipChatPath('ws-1', 'chat-1')).toBe('/workspace/ws-1/chat/chat-1')
+  })
+
+  it('returns the task embed route when embed is true', () => {
+    expect(getMothershipChatPath('ws-1', 'chat-1', { embed: true })).toBe(
+      '/workspace/ws-1/task/chat-1/embed'
+    )
+  })
+
+  it('preserves query strings', () => {
+    expect(getMothershipChatPath('ws-1', 'chat-1', { embed: true, search: '?role=exec' })).toBe(
+      '/workspace/ws-1/task/chat-1/embed?role=exec'
+    )
+    expect(getMothershipChatPath('ws-1', 'chat-1', { search: 'resource=wf-1' })).toBe(
+      '/workspace/ws-1/chat/chat-1?resource=wf-1'
+    )
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/mothership-chat-path.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/mothership-chat-path.ts
@@ -1,0 +1,33 @@
+interface GetMothershipChatPathOptions {
+  /** When true, keep the user on an embed surface (no workspace sidebar). */
+  embed?: boolean
+  /** Optional query string (`?foo=bar` or `foo=bar`). */
+  search?: string
+}
+
+/**
+ * Canonical client URL for an active mothership chat.
+ * Embed surfaces use `/task/:chatId/embed` so workspace chrome stays fullscreen.
+ */
+export function getMothershipChatPath(
+  workspaceId: string,
+  chatId: string,
+  options?: GetMothershipChatPathOptions
+): string {
+  const base = options?.embed
+    ? `/workspace/${workspaceId}/task/${chatId}/embed`
+    : `/workspace/${workspaceId}/chat/${chatId}`
+
+  const rawSearch = options?.search?.trim()
+  if (!rawSearch) return base
+
+  return rawSearch.startsWith('?') ? `${base}${rawSearch}` : `${base}?${rawSearch}`
+}
+
+/**
+ * Reads the current location search string when running in the browser.
+ */
+export function readMothershipChatSearch(): string {
+  if (typeof window === 'undefined') return ''
+  return window.location.search
+}


### PR DESCRIPTION
- Implemented  function to generate chat URLs based on workspace and chat IDs, with options for embedding and query strings.
- Created unit tests for  to validate standard and embed routes.
- Updated  and  hooks to utilize the new chat path logic for URL management.
- Added tests for  to ensure correct URL handling in embed and standard chat scenarios.

## Summary
Brief description of what this PR does and why.

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
