### PR TITLE
Retry copilot Mothership calls with the backup API key on any failure.

### DIFF
--- a/apps/sim/lib/copilot/request/go/fetch.ts
+++ b/apps/sim/lib/copilot/request/go/fetch.ts
@@ -9,7 +9,6 @@ import {
   isCopilotApiKeyFailoverNetworkError,
   isCopilotApiKeyFailoverStatus,
   listCopilotApiKeys,
-  requestUsesCopilotApiKey,
   stripCopilotApiKeyHeader,
 } from '@/lib/copilot/server/copilot-api-keys'
 
@@ -76,10 +75,7 @@ export async function fetchGo(url: string, options: OutboundFetchOptions = {}): 
   }
 
   const headerRecord = mergedHeaders as Record<string, string>
-  const copilotKeys =
-    requestUsesCopilotApiKey(headerRecord) && listCopilotApiKeys().length > 0
-      ? listCopilotApiKeys()
-      : []
+  const copilotKeys = listCopilotApiKeys()
 
   const start = performance.now()
 

--- a/apps/sim/lib/copilot/server/copilot-api-keys.test.ts
+++ b/apps/sim/lib/copilot/server/copilot-api-keys.test.ts
@@ -49,12 +49,14 @@ describe('copilot-api-keys', () => {
     expect(isCopilotApiKeyFailoverStatus(401)).toBe(true)
     expect(isCopilotApiKeyFailoverStatus(429)).toBe(true)
     expect(isCopilotApiKeyFailoverStatus(503)).toBe(true)
-    expect(isCopilotApiKeyFailoverStatus(400)).toBe(false)
-    expect(isCopilotApiKeyFailoverStatus(402)).toBe(false)
+    expect(isCopilotApiKeyFailoverStatus(400)).toBe(true)
+    expect(isCopilotApiKeyFailoverStatus(500)).toBe(true)
+    expect(isCopilotApiKeyFailoverStatus(200)).toBe(false)
   })
 
-  it('treats TypeError as a failover network error but not AbortError', () => {
+  it('retries on fetch errors except AbortError', () => {
     expect(isCopilotApiKeyFailoverNetworkError(new TypeError('fetch failed'))).toBe(true)
+    expect(isCopilotApiKeyFailoverNetworkError(new Error('connection reset'))).toBe(true)
     expect(isCopilotApiKeyFailoverNetworkError(new DOMException('Aborted', 'AbortError'))).toBe(
       false
     )

--- a/apps/sim/lib/copilot/server/copilot-api-keys.ts
+++ b/apps/sim/lib/copilot/server/copilot-api-keys.ts
@@ -1,8 +1,5 @@
 import { env } from '@/lib/core/config/env'
 
-/** HTTP statuses that trigger failover to the next configured copilot API key. */
-const COPILOT_API_KEY_FAILOVER_STATUSES = new Set([401, 403, 429, 502, 503, 504])
-
 /**
  * Returns configured Sim → Mothership API keys in failover order.
  * `COPILOT_API_KEY` is primary; `COPILOT_API_KEY_2` is the optional backup.
@@ -23,17 +20,13 @@ export function hasCopilotApiKey(): boolean {
 }
 
 export function isCopilotApiKeyFailoverStatus(status: number): boolean {
-  return COPILOT_API_KEY_FAILOVER_STATUSES.has(status)
+  return status >= 400
 }
 
-/**
- * Returns true for transient network failures where retrying with the next key
- * may succeed (same Mothership URL, different account credentials).
- */
 export function isCopilotApiKeyFailoverNetworkError(error: unknown): boolean {
-  if (error instanceof TypeError) return true
   if (error instanceof DOMException && error.name === 'AbortError') return false
-  return false
+  if (error instanceof Error && error.name === 'AbortError') return false
+  return true
 }
 
 /**


### PR DESCRIPTION
Fail over on all 4xx/5xx responses and fetch errors (except aborts), and always apply configured copilot keys in fetchGo so the second key is used whenever the first one fails.

## Summary
Brief description of what this PR does and why.

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
How has this been tested? What should reviewers focus on?

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->
