### PR TITLE
fix(video): use hosted Fal.ai as the only video generator provider

### DIFF
--- a/apps/sim/app/api/tools/video/route.ts
+++ b/apps/sim/app/api/tools/video/route.ts
@@ -105,37 +105,36 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     }
 
     // Validate duration (provider-specific constraints)
-    if (provider === 'veo') {
-      if (duration !== undefined && ![4, 6, 8].includes(duration)) {
-        return NextResponse.json(
-          { error: 'Duration must be 4, 6, or 8 seconds for Veo' },
-          { status: 400 }
-        )
-      }
-    } else if (provider === 'minimax') {
-      if (duration !== undefined && ![6, 10].includes(duration)) {
-        return NextResponse.json(
-          { error: 'Duration must be 6 or 10 seconds for MiniMax' },
-          { status: 400 }
-        )
-      }
-    } else if (provider !== 'falai' && duration !== undefined && (duration < 5 || duration > 10)) {
-      // Fal.ai has variable duration constraints per model, skip validation
-      return NextResponse.json(
-        { error: 'Duration must be between 5 and 10 seconds' },
-        { status: 400 }
-      )
-    }
+    // if (provider === 'veo') {
+    //   if (duration !== undefined && ![4, 6, 8].includes(duration)) {
+    //     return NextResponse.json(
+    //       { error: 'Duration must be 4, 6, or 8 seconds for Veo' },
+    //       { status: 400 }
+    //     )
+    //   }
+    // } else if (provider === 'minimax') {
+    //   if (duration !== undefined && ![6, 10].includes(duration)) {
+    //     return NextResponse.json(
+    //       { error: 'Duration must be 6 or 10 seconds for MiniMax' },
+    //       { status: 400 }
+    //     )
+    //   }
+    // } else if (provider !== 'falai' && duration !== undefined && (duration < 5 || duration > 10)) {
+    //   return NextResponse.json(
+    //     { error: 'Duration must be between 5 and 10 seconds' },
+    //     { status: 400 }
+    //   )
+    // }
 
-    if (provider !== 'falai') {
-      const validAspectRatios = provider === 'veo' ? ['16:9', '9:16'] : ['16:9', '9:16', '1:1']
-      if (aspectRatio && !validAspectRatios.includes(aspectRatio)) {
-        return NextResponse.json(
-          { error: `Aspect ratio must be ${validAspectRatios.join(', ')}` },
-          { status: 400 }
-        )
-      }
-    }
+    // if (provider !== 'falai') {
+    //   const validAspectRatios = provider === 'veo' ? ['16:9', '9:16'] : ['16:9', '9:16', '1:1']
+    //   if (aspectRatio && !validAspectRatios.includes(aspectRatio)) {
+    //     return NextResponse.json(
+    //       { error: `Aspect ratio must be ${validAspectRatios.join(', ')}` },
+    //       { status: 400 }
+    //     )
+    //   }
+    // }
 
     logger.info(`[${requestId}] Generating video with ${provider}, model: ${model || 'default'}`)
 
@@ -147,84 +146,88 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     let actualDuration: number | undefined
     let falaiCost: FalAICostMetadata | undefined
 
-    if (body.visualReference) {
-      const denied = await assertToolFileAccess(
-        body.visualReference.key,
-        authResult.userId,
-        requestId,
-        logger
-      )
-      if (denied) return denied
-    }
+    // if (body.visualReference) {
+    //   const denied = await assertToolFileAccess(
+    //     body.visualReference.key,
+    //     authResult.userId,
+    //     requestId,
+    //     logger
+    //   )
+    //   if (denied) return denied
+    // }
 
     try {
-      if (provider === 'runway') {
-        const result = await generateWithRunway(
-          apiKey,
-          model || 'gen-4',
-          prompt,
-          duration || 5,
-          aspectRatio || '16:9',
-          resolution || '1080p',
-          body.visualReference,
-          requestId,
-          logger
-        )
-        videoBuffer = result.buffer
-        width = result.width
-        height = result.height
-        jobId = result.jobId
-        actualDuration = result.duration
-      } else if (provider === 'veo') {
-        const result = await generateWithVeo(
-          apiKey,
-          model || 'veo-3',
-          prompt,
-          duration || 8, // Default to 8 seconds (valid: 4, 6, or 8)
-          aspectRatio || '16:9',
-          resolution || '1080p',
-          requestId,
-          logger
-        )
-        videoBuffer = result.buffer
-        width = result.width
-        height = result.height
-        jobId = result.jobId
-        actualDuration = result.duration
-      } else if (provider === 'luma') {
-        const result = await generateWithLuma(
-          apiKey,
-          model || 'ray-2',
-          prompt,
-          duration || 5,
-          aspectRatio || '16:9',
-          resolution || '1080p',
-          body.cameraControl,
-          requestId,
-          logger
-        )
-        videoBuffer = result.buffer
-        width = result.width
-        height = result.height
-        jobId = result.jobId
-        actualDuration = result.duration
-      } else if (provider === 'minimax') {
-        const result = await generateWithMiniMax(
-          apiKey,
-          model || 'hailuo-2.3',
-          prompt,
-          duration || 6,
-          body.promptOptimizer !== false,
-          body.endpoint,
-          requestId,
-          logger
-        )
-        videoBuffer = result.buffer
-        width = result.width
-        height = result.height
-        jobId = result.jobId
-        actualDuration = result.duration
-      } else if (provider === 'falai') {
+      if (!apiKey) {
+        return NextResponse.json({ error: 'Fal.ai API key is required' }, { status: 400 })
+      }
+      // if (provider === 'runway') {
+      //   const result = await generateWithRunway(
+      //     apiKey,
+      //     model || 'gen-4',
+      //     prompt,
+      //     duration || 5,
+      //     aspectRatio || '16:9',
+      //     resolution || '1080p',
+      //     body.visualReference,
+      //     requestId,
+      //     logger
+      //   )
+      //   videoBuffer = result.buffer
+      //   width = result.width
+      //   height = result.height
+      //   jobId = result.jobId
+      //   actualDuration = result.duration
+      // } else if (provider === 'veo') {
+      //   const result = await generateWithVeo(
+      //     apiKey,
+      //     model || 'veo-3',
+      //     prompt,
+      //     duration || 8,
+      //     aspectRatio || '16:9',
+      //     resolution || '1080p',
+      //     requestId,
+      //     logger
+      //   )
+      //   videoBuffer = result.buffer
+      //   width = result.width
+      //   height = result.height
+      //   jobId = result.jobId
+      //   actualDuration = result.duration
+      // } else if (provider === 'luma') {
+      //   const result = await generateWithLuma(
+      //     apiKey,
+      //     model || 'ray-2',
+      //     prompt,
+      //     duration || 5,
+      //     aspectRatio || '16:9',
+      //     resolution || '1080p',
+      //     body.cameraControl,
+      //     requestId,
+      //     logger
+      //   )
+      //   videoBuffer = result.buffer
+      //   width = result.width
+      //   height = result.height
+      //   jobId = result.jobId
+      //   actualDuration = result.duration
+      // } else if (provider === 'minimax') {
+      //   const result = await generateWithMiniMax(
+      //     apiKey,
+      //     model || 'hailuo-2.3',
+      //     prompt,
+      //     duration || 6,
+      //     body.promptOptimizer !== false,
+      //     body.endpoint,
+      //     requestId,
+      //     logger
+      //   )
+      //   videoBuffer = result.buffer
+      //   width = result.width
+      //   height = result.height
+      //   jobId = result.jobId
+      //   actualDuration = result.duration
+      // } else
+      if (provider === 'falai') {
         if (!model) {
           return NextResponse.json(
             { error: 'Model is required for Fal.ai provider' },
@@ -358,6 +361,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   }
 })
 
+/* Disabled direct provider integrations
 async function generateWithRunway(
   apiKey: string,
   model: string,
@@ -885,6 +889,8 @@ async function generateWithMiniMax(
 
   throw new Error('MiniMax generation timed out')
 }
+
+*/
 
 type FalAIDurationFormat = 'number' | 'seconds' | 'string'
 

--- a/apps/sim/blocks/blocks.test.ts
+++ b/apps/sim/blocks/blocks.test.ts
@@ -897,19 +897,8 @@ describe.concurrent('Blocks Module', () => {
 
       const videoBlock = getBlock('video_generator_v3')
       const videoApiKeySubBlocks = videoBlock?.subBlocks.filter((sb) => sb.id === 'apiKey') ?? []
-      const videoFalApiKeySubBlock = videoApiKeySubBlocks.find(
-        (sb) => sb.condition?.field === 'provider' && sb.condition.value === 'falai'
-      )
-      const videoNonFalApiKeySubBlock = videoApiKeySubBlocks.find(
-        (sb) =>
-          sb.condition?.field === 'provider' &&
-          sb.condition.value === 'falai' &&
-          sb.condition.not === true
-      )
 
-      expect(videoFalApiKeySubBlock?.hideWhenHosted).toBe(true)
-      expect(videoNonFalApiKeySubBlock).toBeDefined()
-      expect(videoNonFalApiKeySubBlock?.hideWhenHosted).not.toBe(true)
+      expect(videoApiKeySubBlocks).toHaveLength(0)
     })
 
     it('should expose reference image inputs and images output on image generator v2', () => {

--- a/apps/sim/blocks/blocks/video_generator.ts
+++ b/apps/sim/blocks/blocks/video_generator.ts
@@ -77,7 +77,7 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
   hideFromToolbar: true,
   authMode: AuthMode.ApiKey,
   longDescription:
-    'Generate high-quality videos from text prompts using leading AI providers. Supports multiple models, aspect ratios, resolutions, and provider-specific features like world consistency, camera controls, and audio generation.',
+    'Generate high-quality videos from text prompts via hosted Fal.ai. Supports multiple models (including Veo, Sora, Kling, MiniMax, WAN, and LTX), aspect ratios, resolutions, prompt optimization, and native audio controls.',
   docsLink: 'https://docs.sim.ai/integrations/video-generator',
   category: 'blocks',
   integrationType: IntegrationType.AI,
@@ -840,12 +840,12 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
   inputs: {
     provider: {
       type: 'string',
-      description: 'Video generation provider (runway, veo, luma, minimax, falai)',
+      description: 'Video generation provider (falai)',
     },
     // apiKey: { type: 'string', description: 'Provider API key' },
     model: {
       type: 'string',
-      description: 'Provider-specific model',
+      description: 'Fal.ai model',
     },
     endpoint: {
       type: 'string',
@@ -855,11 +855,11 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
     duration: { type: 'number', description: 'Video duration in seconds' },
     aspectRatio: {
       type: 'string',
-      description: 'Aspect ratio for supported providers and models',
+      description: 'Aspect ratio for supported models',
     },
     resolution: {
       type: 'string',
-      description: 'Video resolution for supported providers and models',
+      description: 'Video resolution for supported models',
     },
     visualReference: { type: 'json', description: 'Reference image for Runway (UserFile)' },
     consistencyMode: {
@@ -1616,12 +1616,12 @@ export const VideoGeneratorV2Block: BlockConfig<VideoBlockResponse> = {
   inputs: {
     provider: {
       type: 'string',
-      description: 'Video generation provider (runway, veo, luma, minimax, falai)',
+      description: 'Video generation provider (falai)',
     },
     // apiKey: { type: 'string', description: 'Provider API key' },
     model: {
       type: 'string',
-      description: 'Provider-specific model',
+      description: 'Fal.ai model',
     },
     endpoint: {
       type: 'string',
@@ -1631,11 +1631,11 @@ export const VideoGeneratorV2Block: BlockConfig<VideoBlockResponse> = {
     duration: { type: 'number', description: 'Video duration in seconds' },
     aspectRatio: {
       type: 'string',
-      description: 'Aspect ratio for supported providers and models',
+      description: 'Aspect ratio for supported models',
     },
     resolution: {
       type: 'string',
-      description: 'Video resolution for supported providers and models',
+      description: 'Video resolution for supported models',
     },
     visualReference: { type: 'json', description: 'Reference image for Runway (UserFile)' },
     consistencyMode: {
@@ -1664,7 +1664,7 @@ export const VideoGeneratorV3Block: BlockConfig<VideoBlockResponse> = {
   name: 'Video Generator',
   description: 'Generate videos from text using AI',
   longDescription:
-    'Generate high-quality videos from text prompts using leading AI providers. Supports Runway, Google Veo, Luma, MiniMax, and Fal.ai multi-model generation with provider-specific durations, aspect ratios, resolutions, prompt optimization, and native audio controls.',
+    'Generate high-quality videos from text prompts via hosted Fal.ai. Supports multiple models (including Veo, Sora, Kling, MiniMax, Seedance, WAN, and LTX), aspect ratios, resolutions, prompt optimization, and native audio controls.',
   docsLink: 'https://docs.sim.ai/integrations/video_generator',
   category: 'blocks',
   integrationType: IntegrationType.AI,

--- a/apps/sim/blocks/blocks/video_generator.ts
+++ b/apps/sim/blocks/blocks/video_generator.ts
@@ -91,10 +91,10 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
       title: 'Provider',
       type: 'dropdown',
       options: [
-        { label: 'Runway Gen-4', id: 'runway' },
-        { label: 'Google Veo 3', id: 'veo' },
-        { label: 'Luma Dream Machine', id: 'luma' },
-        { label: 'MiniMax Hailuo', id: 'minimax' },
+        // { label: 'Runway Gen-4', id: 'runway' },
+        // { label: 'Google Veo 3', id: 'veo' },
+        // { label: 'Luma Dream Machine', id: 'luma' },
+        // { label: 'MiniMax Hailuo', id: 'minimax' },
         { label: 'Fal.ai (Multi-Model)', id: 'falai' },
       ],
       value: () => 'falai',
@@ -767,46 +767,51 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
       dependsOn: ['model'],
     },
 
-    // API Key
-    {
-      id: 'apiKey',
-      title: 'API Key',
-      type: 'short-input',
-      placeholder: 'Enter your provider API key',
-      password: true,
-      required: true,
-      hideWhenHosted: true,
-      condition: { field: 'provider', value: 'falai' },
-    },
-    {
-      id: 'apiKey',
-      title: 'API Key',
-      type: 'short-input',
-      placeholder: 'Enter your provider API key',
-      password: true,
-      required: true,
-      condition: { field: 'provider', value: 'falai', not: true },
-    },
+    // API Key (hosted Fal.ai key is injected by Sim)
+    // {
+    //   id: 'apiKey',
+    //   title: 'API Key',
+    //   type: 'short-input',
+    //   placeholder: 'Enter your Fal.ai API key',
+    //   password: true,
+    //   required: true,
+    //   hideWhenHosted: true,
+    // },
+    // {
+    //   id: 'apiKey',
+    //   title: 'API Key',
+    //   type: 'short-input',
+    //   placeholder: 'Enter your provider API key',
+    //   password: true,
+    //   required: true,
+    //   condition: { field: 'provider', value: 'falai', not: true },
+    // },
   ],
 
   tools: {
-    access: ['video_runway', 'video_veo', 'video_luma', 'video_minimax', 'video_falai'],
+    access: [
+      // 'video_runway',
+      // 'video_veo',
+      // 'video_luma',
+      // 'video_minimax',
+      'video_falai',
+    ],
     config: {
       tool: (params) => {
         // Select tool based on provider
         switch (params.provider) {
-          case 'runway':
-            return 'video_runway'
-          case 'veo':
-            return 'video_veo'
-          case 'luma':
-            return 'video_luma'
-          case 'minimax':
-            return 'video_minimax'
+          // case 'runway':
+          //   return 'video_runway'
+          // case 'veo':
+          //   return 'video_veo'
+          // case 'luma':
+          //   return 'video_luma'
+          // case 'minimax':
+          //   return 'video_minimax'
           case 'falai':
             return 'video_falai'
           default:
-            return 'video_runway'
+            return 'video_falai'
         }
       },
       params: (params) => ({
@@ -837,7 +842,7 @@ export const VideoGeneratorBlock: BlockConfig<VideoBlockResponse> = {
       type: 'string',
       description: 'Video generation provider (runway, veo, luma, minimax, falai)',
     },
-    apiKey: { type: 'string', description: 'Provider API key' },
+    // apiKey: { type: 'string', description: 'Provider API key' },
     model: {
       type: 'string',
       description: 'Provider-specific model',
@@ -898,10 +903,10 @@ export const VideoGeneratorV2Block: BlockConfig<VideoBlockResponse> = {
       title: 'Provider',
       type: 'dropdown',
       options: [
-        { label: 'Runway Gen-4', id: 'runway' },
-        { label: 'Google Veo 3', id: 'veo' },
-        { label: 'Luma Dream Machine', id: 'luma' },
-        { label: 'MiniMax Hailuo', id: 'minimax' },
+        // { label: 'Runway Gen-4', id: 'runway' },
+        // { label: 'Google Veo 3', id: 'veo' },
+        // { label: 'Luma Dream Machine', id: 'luma' },
+        // { label: 'MiniMax Hailuo', id: 'minimax' },
         { label: 'Fal.ai (Multi-Model)', id: 'falai' },
       ],
       commandSearchable: true,
@@ -1541,43 +1546,49 @@ export const VideoGeneratorV2Block: BlockConfig<VideoBlockResponse> = {
       },
       dependsOn: ['model'],
     },
-    {
-      id: 'apiKey',
-      title: 'API Key',
-      type: 'short-input',
-      placeholder: 'Enter your provider API key',
-      password: true,
-      required: true,
-      hideWhenHosted: true,
-      condition: { field: 'provider', value: 'falai' },
-    },
-    {
-      id: 'apiKey',
-      title: 'API Key',
-      type: 'short-input',
-      placeholder: 'Enter your provider API key',
-      password: true,
-      required: true,
-      condition: { field: 'provider', value: 'falai', not: true },
-    },
+    // API Key (hosted Fal.ai key is injected by Sim)
+    // {
+    //   id: 'apiKey',
+    //   title: 'API Key',
+    //   type: 'short-input',
+    //   placeholder: 'Enter your Fal.ai API key',
+    //   password: true,
+    //   required: true,
+    //   hideWhenHosted: true,
+    // },
+    // {
+    //   id: 'apiKey',
+    //   title: 'API Key',
+    //   type: 'short-input',
+    //   placeholder: 'Enter your provider API key',
+    //   password: true,
+    //   required: true,
+    //   condition: { field: 'provider', value: 'falai', not: true },
+    // },
   ],
   tools: {
-    access: ['video_runway', 'video_veo', 'video_luma', 'video_minimax', 'video_falai'],
+    access: [
+      // 'video_runway',
+      // 'video_veo',
+      // 'video_luma',
+      // 'video_minimax',
+      'video_falai',
+    ],
     config: {
       tool: (params) => {
         switch (params.provider) {
-          case 'runway':
-            return 'video_runway'
-          case 'veo':
-            return 'video_veo'
-          case 'luma':
-            return 'video_luma'
-          case 'minimax':
-            return 'video_minimax'
+          // case 'runway':
+          //   return 'video_runway'
+          // case 'veo':
+          //   return 'video_veo'
+          // case 'luma':
+          //   return 'video_luma'
+          // case 'minimax':
+          //   return 'video_minimax'
           case 'falai':
             return 'video_falai'
           default:
-            return 'video_runway'
+            return 'video_falai'
         }
       },
       params: (params) => ({
@@ -1607,7 +1618,7 @@ export const VideoGeneratorV2Block: BlockConfig<VideoBlockResponse> = {
       type: 'string',
       description: 'Video generation provider (runway, veo, luma, minimax, falai)',
     },
-    apiKey: { type: 'string', description: 'Provider API key' },
+    // apiKey: { type: 'string', description: 'Provider API key' },
     model: {
       type: 'string',
       description: 'Provider-specific model',

--- a/apps/sim/lib/api/contracts/tools/media/video.ts
+++ b/apps/sim/lib/api/contracts/tools/media/video.ts
@@ -3,8 +3,14 @@ import { userFileSchema } from '@/lib/api/contracts/primitives'
 import { toolBooleanSchema, toolJsonResponseSchema } from '@/lib/api/contracts/tools/media/shared'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 
-export const videoProviders = ['runway', 'veo', 'luma', 'minimax', 'falai'] as const
-const MISSING_VIDEO_FIELDS_ERROR = 'Missing required fields: provider, apiKey, and prompt'
+export const videoProviders = [
+  // 'runway',
+  // 'veo',
+  // 'luma',
+  // 'minimax',
+  'falai',
+] as const
+const MISSING_VIDEO_FIELDS_ERROR = 'Missing required fields: provider and prompt'
 
 export const videoToolBodySchema = z
   .object({
@@ -14,7 +20,7 @@ export const videoToolBodySchema = z
       .refine((provider) => videoProviders.includes(provider as (typeof videoProviders)[number]), {
         message: `Invalid provider. Must be one of: ${videoProviders.join(', ')}`,
       }),
-    apiKey: z.string({ error: MISSING_VIDEO_FIELDS_ERROR }).min(1, MISSING_VIDEO_FIELDS_ERROR),
+    apiKey: z.string().optional(),
     model: z.string().optional(),
     prompt: z.string({ error: MISSING_VIDEO_FIELDS_ERROR }).min(1, MISSING_VIDEO_FIELDS_ERROR),
     duration: z.coerce.number().optional(),

--- a/apps/sim/tools/registry.ts
+++ b/apps/sim/tools/registry.ts
@@ -4429,10 +4429,10 @@ import {
 } from '@/tools/vercel'
 import {
   falaiVideoTool,
-  lumaVideoTool,
-  minimaxVideoTool,
-  runwayVideoTool,
-  veoVideoTool,
+  // lumaVideoTool,
+  // minimaxVideoTool,
+  // runwayVideoTool,
+  // veoVideoTool,
 } from '@/tools/video'
 import { visionTool, visionToolV2 } from '@/tools/vision'
 import {
@@ -7445,10 +7445,10 @@ export const tools: Record<string, ToolConfig> = {
   tts_google: googleTtsTool,
   tts_azure: azureTtsTool,
   tts_playht: playhtTtsTool,
-  video_runway: runwayVideoTool,
-  video_veo: veoVideoTool,
-  video_luma: lumaVideoTool,
-  video_minimax: minimaxVideoTool,
+  // video_runway: runwayVideoTool,
+  // video_veo: veoVideoTool,
+  // video_luma: lumaVideoTool,
+  // video_minimax: minimaxVideoTool,
   video_falai: falaiVideoTool,
   s3_get_object: s3GetObjectTool,
   s3_put_object: s3PutObjectTool,

--- a/apps/sim/tools/video/index.ts
+++ b/apps/sim/tools/video/index.ts
@@ -1,7 +1,7 @@
 import { falaiVideoTool } from '@/tools/video/falai'
-import { lumaVideoTool } from '@/tools/video/luma'
-import { minimaxVideoTool } from '@/tools/video/minimax'
-import { runwayVideoTool } from '@/tools/video/runway'
-import { veoVideoTool } from '@/tools/video/veo'
+// import { lumaVideoTool } from '@/tools/video/luma'
+// import { minimaxVideoTool } from '@/tools/video/minimax'
+// import { runwayVideoTool } from '@/tools/video/runway'
+// import { veoVideoTool } from '@/tools/video/veo'
 
-export { runwayVideoTool, veoVideoTool, lumaVideoTool, minimaxVideoTool, falaiVideoTool }
+export { falaiVideoTool /* , runwayVideoTool, veoVideoTool, lumaVideoTool, minimaxVideoTool */ }

--- a/apps/sim/tools/video/luma.ts
+++ b/apps/sim/tools/video/luma.ts
@@ -1,3 +1,4 @@
+/* Disabled direct provider integration
 import type { ToolConfig } from '@/tools/types'
 import type { VideoParams, VideoResponse } from '@/tools/video/types'
 
@@ -133,3 +134,5 @@ export const lumaVideoTool: ToolConfig<VideoParams, VideoResponse> = {
     jobId: { type: 'string', description: 'Luma job ID' },
   },
 }
+
+*/

--- a/apps/sim/tools/video/minimax.ts
+++ b/apps/sim/tools/video/minimax.ts
@@ -1,3 +1,4 @@
+/* Disabled direct provider integration
 import type { ToolConfig } from '@/tools/types'
 import type { VideoParams, VideoResponse } from '@/tools/video/types'
 import { parseBooleanParamWithDefault } from '@/tools/video/utils'
@@ -127,3 +128,5 @@ export const minimaxVideoTool: ToolConfig<VideoParams, VideoResponse> = {
     jobId: { type: 'string', description: 'MiniMax job ID' },
   },
 }
+
+*/

--- a/apps/sim/tools/video/runway.ts
+++ b/apps/sim/tools/video/runway.ts
@@ -1,3 +1,4 @@
+/* Disabled direct provider integration
 import type { ToolConfig } from '@/tools/types'
 import type { VideoParams, VideoResponse } from '@/tools/video/types'
 
@@ -133,3 +134,5 @@ export const runwayVideoTool: ToolConfig<VideoParams, VideoResponse> = {
     jobId: { type: 'string', description: 'Runway job ID' },
   },
 }
+
+*/

--- a/apps/sim/tools/video/veo.ts
+++ b/apps/sim/tools/video/veo.ts
@@ -1,3 +1,4 @@
+/* Disabled direct provider integration
 import type { ToolConfig } from '@/tools/types'
 import type { VideoParams, VideoResponse } from '@/tools/video/types'
 
@@ -126,3 +127,5 @@ export const veoVideoTool: ToolConfig<VideoParams, VideoResponse> = {
     jobId: { type: 'string', description: 'Veo job ID' },
   },
 }
+
+*/


### PR DESCRIPTION
Disable direct Runway, Veo, Luma, and MiniMax integrations and remove the user-facing API key so workflows rely on the backend Fal.ai key.
