### PR TITLE
fix(deploy): pin p2prod to our GHCR tags, skip auto migrations

### DIFF
--- a/docker-compose.p2prod.yml
+++ b/docker-compose.p2prod.yml
@@ -1,6 +1,6 @@
 services:
   simstudio:
-    image: ghcr.io/simstudioai/simstudio:latest
+    image: ghcr.io/arenadeveloper02/p2-sim-simstudio:${IMAGE_TAG:-dev}
     restart: unless-stopped
     ports:
       - '3000:3000'
@@ -58,7 +58,7 @@ services:
       start_period: 10s
 
   realtime:
-    image: ghcr.io/simstudioai/realtime:latest
+    image: ghcr.io/arenadeveloper02/p2-sim-realtime:${IMAGE_TAG:-dev}
     restart: unless-stopped
     ports:
       - '3002:3002'
@@ -86,8 +86,10 @@ services:
       retries: 3
       start_period: 10s
 
+  # Kept for optional manual runs (`docker compose run --rm migrations`).
+  # Deploy scripts intentionally do not start this service — migrations are applied manually.
   migrations:
-    image: ghcr.io/simstudioai/migrations:latest
+    image: ghcr.io/arenadeveloper02/p2-sim-migrations:${IMAGE_TAG:-dev}
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-simstudio}
     depends_on:
@@ -95,6 +97,8 @@ services:
         condition: service_healthy
     command: ["bun", "run", "db:migrate"]
     restart: "no"
+    profiles:
+      - migrations
 
   db:
     image: pgvector/pgvector:pg17

--- a/scripts/deploy-ec2-ghcr.sh
+++ b/scripts/deploy-ec2-ghcr.sh
@@ -71,10 +71,13 @@ fi
 
 echo "Deploying IMAGE_TAG=${IMAGE_TAG}"
 echo "Using compose file: ${COMPOSE_FILE}"
+echo "Note: migrations are not started by this script; run them manually when ready."
 
 cd "$DEPLOY_ROOT"
-docker compose "${COMPOSE_ENV_ARGS[@]}" -f "$COMPOSE_FILE" pull simstudio realtime migrations
-docker compose "${COMPOSE_ENV_ARGS[@]}" -f "$COMPOSE_FILE" up -d --remove-orphans
+# Pull app images only. Migrations stay manual (p2prod puts them behind the
+# `migrations` compose profile; do not auto-start them here).
+docker compose "${COMPOSE_ENV_ARGS[@]}" -f "$COMPOSE_FILE" pull simstudio realtime
+docker compose "${COMPOSE_ENV_ARGS[@]}" -f "$COMPOSE_FILE" up -d --remove-orphans simstudio realtime db
 
 deadline=$((SECONDS + ${DEPLOY_HEALTH_TIMEOUT_SECONDS:-240}))
 


### PR DESCRIPTION
Stop pulling upstream simstudioai:latest (schema drift vs our DB) and keep migrations manual so deploy no longer races or applies the wrong migrator.