### PR TITLE
fix(arena): show Back to Arena agents after /workspace

### DIFF
--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -7,6 +7,7 @@ import { BrandedLayout } from '@/components/branded-layout'
 import { PostHogProvider } from '@/app/_shell/providers/posthog-provider'
 import { generateBrandedMetadata, generateThemeCSS } from '@/ee/whitelabeling'
 import '@/app/_styles/globals.css'
+import { getEnv } from '@/lib/core/config/env'
 import { isHosted, isReactGrabEnabled, isReactScanEnabled } from '@/lib/core/config/env-flags'
 import { HydrationErrorHandler } from '@/app/_shell/hydration-error-handler'
 import { AutoLoginProvider } from '@/app/_shell/providers/auto-login-provider'
@@ -32,6 +33,18 @@ export const metadata: Metadata = generateBrandedMetadata()
 
 const GTM_ID = 'GTM-T7PHSRX5' as const
 const GA_ID = 'G-DR7YBE70VS' as const
+
+/**
+ * Static PublicEnvScript is only safe when public env is fixed per image build
+ * (sim.ai hosted). Arena agent hosts share one GHCR image across envs and must
+ * inject `NEXT_PUBLIC_*` at request time via next-runtime-env.
+ */
+function useRuntimePublicEnvScript(): boolean {
+  const appUrl = getEnv('NEXT_PUBLIC_APP_URL')
+  return (
+    appUrl !== 'https://www.sim.ai' && appUrl !== 'https://www.staging.sim.ai'
+  )
+}
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const themeCSS = generateThemeCSS()
@@ -263,7 +276,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </>
         )}
 
-        {isHosted ? <PublicEnvScript /> : <RuntimePublicEnvScript />}
+        {useRuntimePublicEnvScript() ? <RuntimePublicEnvScript /> : <PublicEnvScript />}
       </head>
       <body className={`${season.variable} font-season`} suppressHydrationWarning>
         {/* Google Tag Manager (noscript) — hosted only */}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-brand-header/sidebar-brand-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-brand-header/sidebar-brand-header.tsx
@@ -85,7 +85,7 @@ export function SidebarBrandHeader({
       {arenaHubAgentsUrl ? (
         <div className='flex flex-shrink-0 flex-col px-2 pt-2 pb-0'>
           <SidebarTooltip label='Back to Arena agents' enabled={showCollapsedTooltips} side='right'>
-            <Link
+            <a
               href={arenaHubAgentsUrl}
               className={chipVariants({ fullWidth: true })}
               aria-label='Back to Arena agents'
@@ -94,7 +94,7 @@ export function SidebarBrandHeader({
               <span className='sidebar-collapse-hide truncate text-[var(--text-body)]'>
                 Back to Arena agents
               </span>
-            </Link>
+            </a>
           </SidebarTooltip>
         </div>
       ) : null}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -41,8 +41,8 @@ import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigat
 import { usePostHog } from 'posthog-js/react'
 import { useSession } from '@/lib/auth/auth-client'
 import { SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
-import { getEnv } from '@/lib/core/config/env'
 import { isMacPlatform } from '@/lib/core/utils/platform'
+import { getArenaHubAgentsUrl } from '@/lib/core/utils/urls'
 import { buildFolderTree, getFolderPath } from '@/lib/folders/tree'
 import { captureEvent } from '@/lib/posthog/client'
 import { createWorkflowEvent } from '@/app/arenaMixpanelEvents/mixpanelEvents'
@@ -407,11 +407,15 @@ export const Sidebar = memo(function Sidebar({ isCollapsed }: SidebarProps) {
 
   const isMac = isMacPlatform()
 
-  const arenaHubAgentsUrl = useMemo(() => {
-    const base = getEnv('NEXT_PUBLIC_ARENA_FRONTEND_APP_URL')
-    if (!base?.trim()) return null
-    return `${base.replace(/\/$/, '')}/hub/agents`
-  }, [])
+  const [arenaHubAgentsUrl, setArenaHubAgentsUrl] = useState<string | null>(() =>
+    getArenaHubAgentsUrl()
+  )
+
+  useEffect(() => {
+    if (arenaHubAgentsUrl) return
+    const resolved = getArenaHubAgentsUrl()
+    if (resolved) setArenaHubAgentsUrl(resolved)
+  }, [arenaHubAgentsUrl])
 
   const [showCollapsedTooltips, setShowCollapsedTooltips] = useState(isCollapsed)
 

--- a/apps/sim/app/workspace/page.tsx
+++ b/apps/sim/app/workspace/page.tsx
@@ -70,7 +70,10 @@ export default function WorkspacePage() {
     }
 
     logger.info(`Redirecting to workspace: ${targetWorkspace.id}`)
-    router.replace(`/workspace/${targetWorkspace.id}/home`)
+    // Full navigation so workspace chrome (incl. Back to Arena agents) mounts with
+    // a fresh document and runtime public env — client soft-nav from /workspace can
+    // miss NEXT_PUBLIC_ARENA_FRONTEND_APP_URL when the shell was statically baked.
+    window.location.replace(`/workspace/${targetWorkspace.id}/home`)
   }, [session, isSessionPending, isWorkspacesLoading, data, router])
 
   if (isSessionPending || isWorkspacesLoading) {
@@ -102,7 +105,7 @@ async function handleWorkflowRedirect(
   } catch (error) {
     logger.error('Error fetching workflow for redirect:', error)
   }
-  router.replace(`/workspace/${fallbackWorkspaceId}/home`)
+  window.location.replace(`/workspace/${fallbackWorkspaceId}/home`)
 }
 
 async function handleNoWorkspaces(
@@ -126,7 +129,7 @@ async function handleNoWorkspaces(
     })
     if (data.workspace?.id) {
       logger.info(`Created default workspace: ${data.workspace.id}`)
-      router.replace(`/workspace/${data.workspace.id}/home`)
+      window.location.replace(`/workspace/${data.workspace.id}/home`)
       return
     }
     logger.error('Failed to create default workspace')

--- a/apps/sim/lib/core/utils/urls.test.ts
+++ b/apps/sim/lib/core/utils/urls.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/core/config/env-flags', () => ({
 }))
 
 import {
+  getArenaHubAgentsUrl,
   getBrowserOrigin,
   getSocketUrl,
   isLocalhostUrl,
@@ -84,6 +85,45 @@ describe('getSocketUrl', () => {
     mockGetEnv.mockImplementation((key) => (key === 'NEXT_PUBLIC_SOCKET_URL' ? '   ' : undefined))
     setLocation('https://app.example.com/')
     expect(getSocketUrl()).toBe('https://app.example.com')
+  })
+})
+
+describe('getArenaHubAgentsUrl', () => {
+  beforeEach(() => {
+    mockGetEnv.mockReset()
+    mockGetEnv.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prefers NEXT_PUBLIC_ARENA_FRONTEND_APP_URL when set', () => {
+    mockGetEnv.mockImplementation((key) =>
+      key === 'NEXT_PUBLIC_ARENA_FRONTEND_APP_URL' ? 'https://dev.thearena.ai/' : undefined
+    )
+    expect(getArenaHubAgentsUrl('dev-agent.thearena.ai')).toBe(
+      'https://dev.thearena.ai/hub/agents'
+    )
+  })
+
+  it('falls back to hostname mapping when env is unset', () => {
+    expect(getArenaHubAgentsUrl('dev-agent.thearena.ai')).toBe(
+      'https://dev.thearena.ai/hub/agents'
+    )
+    expect(getArenaHubAgentsUrl('test-agent.thearena.ai')).toBe(
+      'https://test.thearena.ai/hub/agents'
+    )
+    expect(getArenaHubAgentsUrl('agent.thearena.ai')).toBe('https://app.thearena.ai/hub/agents')
+  })
+
+  it('uses window.location.hostname when no hostname arg is passed', () => {
+    setLocation('https://dev-agent.thearena.ai/workspace')
+    expect(getArenaHubAgentsUrl()).toBe('https://dev.thearena.ai/hub/agents')
+  })
+
+  it('returns null for unknown hosts without env', () => {
+    expect(getArenaHubAgentsUrl('example.com')).toBeNull()
   })
 })
 

--- a/apps/sim/lib/core/utils/urls.ts
+++ b/apps/sim/lib/core/utils/urls.ts
@@ -158,6 +158,46 @@ export function isLoopbackHostname(hostname: string): boolean {
 }
 
 /**
+ * Arena hub "agents" URL for the sidebar back-link.
+ *
+ * Prefers `NEXT_PUBLIC_ARENA_FRONTEND_APP_URL` (via `getEnv` so shared GHCR images
+ * pick up runtime env). Falls back to hostname mapping when the public env is
+ * missing on the client after soft navigation from `/workspace`.
+ */
+export function getArenaHubAgentsUrl(hostname?: string): string | null {
+  const base = getEnv('NEXT_PUBLIC_ARENA_FRONTEND_APP_URL')?.trim()
+  if (base) {
+    return `${base.replace(/\/$/, '')}/hub/agents`
+  }
+
+  const host =
+    hostname ?? (typeof window !== 'undefined' ? window.location.hostname : undefined)
+  if (!host) return null
+
+  if (LOCALHOST_HOSTNAMES.has(host) || host.includes('localhost')) {
+    return 'http://localhost:3001/hub/agents'
+  }
+  if (host === 'dev-agent.thearena.ai' || host.includes('dev-agent')) {
+    return 'https://dev.thearena.ai/hub/agents'
+  }
+  if (
+    host === 'test-agent.thearena.ai' ||
+    host === 'test-v1-agent.thearena.ai' ||
+    host.includes('test-agent')
+  ) {
+    return 'https://test.thearena.ai/hub/agents'
+  }
+  if (host === 'sandbox-agent.thearena.ai' || host.includes('sandbox-agent')) {
+    return 'https://sandbox.thearena.ai/hub/agents'
+  }
+  if (host === 'agent.thearena.ai') {
+    return 'https://app.thearena.ai/hub/agents'
+  }
+
+  return null
+}
+
+/**
  * Parses a comma-separated list of origins (e.g. from a `TRUSTED_ORIGINS` env
  * var) into a deduped array of normalized origins. Invalid entries are dropped.
  *


### PR DESCRIPTION
Soft-nav missed runtime public env; resolve hub URL via hostname fallback and full-document home redirects.
Here’s what each change does and why:

1. [apps/sim/lib/core/utils/urls.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/lib/core/utils/urls.ts) — getArenaHubAgentsUrl()
New helper that builds the hub link (…/hub/agents).

First tries NEXT_PUBLIC_ARENA_FRONTEND_APP_URL via getEnv (works with runtime env on shared GHCR images).
If that’s missing on the client, falls back by hostname (dev-agent → dev.thearena.ai, test-agent → test.thearena.ai, etc.).
That’s the same pattern chat already used, so the sidebar isn’t blocked when public env isn’t on window.__ENV.

2. [apps/sim/lib/core/utils/urls.test.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/lib/core/utils/urls.test.ts)
Unit tests for that helper: env wins, hostname fallback, window.location when no arg, null for unknown hosts.

3. [apps/sim/app/workspace/.../sidebar/sidebar.tsx](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/app/workspace/%5BworkspaceId%5D/w/components/sidebar/sidebar.tsx)
Stopped reading only getEnv once in useMemo([]).

Initializes from getArenaHubAgentsUrl().
If still null after mount (soft-nav / missing env), a useEffect resolves again from hostname and sets the URL so Back to Arena agents appears.
4. [sidebar-brand-header.tsx](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/app/workspace/%5BworkspaceId%5D/w/components/sidebar/components/sidebar-brand-header/sidebar-brand-header.tsx)
Hub link is a plain <a href={arenaHubAgentsUrl}> instead of Next Link.

Link is for in-app routes; this is an external Arena hub URL, so a normal anchor is correct.

5. [apps/sim/app/layout.tsx](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/app/layout.tsx)
Arena agent hosts used to be treated as “hosted” and got the static (build-time) PublicEnvScript. Shared images often bake empty/wrong NEXT_PUBLIC_*.

Now only sim.ai / staging.sim.ai use the static script. Arena (and everything else) uses runtime PublicEnvScript from next-runtime-env, so window.__ENV gets container env at request time — including NEXT_PUBLIC_ARENA_FRONTEND_APP_URL.

6. [apps/sim/app/workspace/page.tsx](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/apps/sim/app/workspace/page.tsx)
/workspace → home used router.replace (client soft-nav). That can keep a shell where public env never got injected, so the sidebar link stayed missing until a hard refresh.

Those home redirects now use window.location.replace(...):

main redirect to /workspace/{id}/home
workflow-redirect fallback to home
after creating a default workspace → home
Full document load remounts chrome with runtime env + hostname fallback.