### PR TITLE
upstream-sync: v0.7.30 → stack tip (2026-08-06-2)

### DIFF
--- a/.upstream-sync/SYNC-BRANCH.md
+++ b/.upstream-sync/SYNC-BRANCH.md
@@ -1,14 +1,14 @@
 # Upstream sync branch
 
-Draft PR: `upstream-sync/2026-08-05T10-46-19` → `feat/github-merge-agent`.
+Draft PR: `upstream-sync/2026-08-06T11-22-06` → `upstream-sync/2026-08-05T10-46-19`.
 
 | | |
 |---|---|
-| Run | `2026-08-05` |
-| Sync branch | `upstream-sync/2026-08-05T10-46-19` |
-| Merge into | `feat/github-merge-agent` |
-| Upstream | [simstudioai/sim@6c3d11b2](https://github.com/simstudioai/sim/commit/6c3d11b2df6c1c18490a27dab17b48d881045918) |
-| Opened | 2026-08-05T10:46:24.227Z |
+| Run | `2026-08-06-2` |
+| Sync branch | `upstream-sync/2026-08-06T11-22-06` |
+| Merge into | `upstream-sync/2026-08-05T10-46-19` |
+| Upstream | [simstudioai/sim@207785c8](https://github.com/simstudioai/sim/commit/207785c8e4a700b085ec317e433748c6e327ee2e) |
+| Opened | 2026-08-06T11:22:10.438Z |
 
 This note exists so the sync branch is always one commit ahead of the merge target when the draft PR opens.
 See `.upstream-sync/ledger/` for the full run ledger.

--- a/.upstream-sync/ledger/2026-08-06-2/fbi-report.md
+++ b/.upstream-sync/ledger/2026-08-06-2/fbi-report.md
@@ -1,0 +1,32 @@
+# FBI Report — 2026-08-06-2
+
+## Upstream commits in this sync
+
+- **2026-07-10** | `9ee499e9` | simstudioai/sim#5589 | fix(canvas): raw tooltip shows up when hovering block params (#5589)
+- **2026-07-10** | `2ba0b583` | simstudioai/sim#5590 | fix(rich-markdown-editor): reliable image selection + serialization/paste polish (#5590)
+- **2026-07-11** | `3d02bbbe` | simstudioai/sim#5593 | fix(mcp): coerce corrupted consecutiveFailures instead of crashing the whole server list (#5593)
+- **2026-07-11** | `fca5f10f` | simstudioai/sim#5586 | feat(workflow-editor): open block palette on edge drag-release with auto-connect (#5586)
+- **2026-07-11** | `3a2f4e5c` | simstudioai/sim#5532 | feat(custom-blocks): add deploy_custom_block copilot tool (#5532)
+- **2026-07-11** | `d14c3047` | simstudioai/sim#5592 | fix(og-image): match sim.ai OG image colors to live landing tokens (#5592)
+- **2026-07-11** | `591516a9` | simstudioai/sim#5594 | fix(rich-markdown-editor): fix mention chip losing ambient color inside links/h6 (#5594)
+- **2026-07-11** | `def2d529` | simstudioai/sim#5598 | fix(docs-og-image): match reference cover template typography exactly (#5598)
+- **2026-07-11** | `7c2de1d4` | simstudioai/sim#5574 | feat(providers): add xAI to hosted key rotation pool (#5574)
+- **2026-07-11** | `b486aba0` | simstudioai/sim#5602 | fix(pricing): route Talk to sales CTA to demo request form instead of signup (#5602)
+- **2026-07-11** | `e2e29eed` | simstudioai/sim#5601 | fix(api): bound request-body reads on speech/knowledge-chunks/help routes (#5601)
+- **2026-07-11** | `b7311622` | simstudioai/sim#5599 | fix(file-viewer): sanitize docx hyperlink hrefs to block javascript: XSS (#5599)
+- **2026-07-11** | `eb123330` | simstudioai/sim#5600 | fix(chat-otp): re-check authType before minting deployment auth cookie (#5600)
+- **2026-07-11** | `67a2f002` | simstudioai/sim#5597 | perf(search): cap Cmd-K result groups so typing isn't blocked by reshuffle (#5597)
+- **2026-07-11** | `d165712d` | simstudioai/sim#5604 | fix(files-upload): enforce workspace authorization on mothership uploads (#5604)
+- **2026-07-11** | `0aa23090` | simstudioai/sim#5608 | fix(files): unwedge post-stream read-only editor; stop bullet Backspace from destroying the image below (#5608)
+- **2026-07-11** | `83c532ce` | simstudioai/sim#5610 | improvement(files): show loading spinner in file preview content area (#5610)
+- **2026-07-11** | `fcf4e029` | simstudioai/sim#5605 | fix(landing): repair Lighthouse-flagged CWV audits on production (#5605)
+- **2026-07-11** | `b629292d` | simstudioai/sim#5612 | improvement(chat): shimmer active subagent and tool labels instead of spinners (#5612)
+- **2026-07-11** | `1b82b976` | simstudioai/sim#5613 | fix(custom-blocks): restrict iconUrl to https or internal serve paths (#5613)
+- **2026-07-11** | `0cc6ed61` | simstudioai/sim#5614 | improvement(emcn): multi-select selectors + Wizard on ChipModal (#5614)
+- **2026-07-11** | `a2f868c3` | simstudioai/sim#5616 | fix(demo): preload the Cal.com booking embed while the visitor fills the form (#5616)
+- **2026-07-11** | `f477faab` | simstudioai/sim#5617 | fix(rich-markdown-editor): make drag-reorder of an image actually move it, on real browser payloads (#5617)
+- **2026-07-11** | `207785c8` | no-pr | v0.7.30: md editor improvements, og image updates, spacexai hosted keys, cmd-k speedups, pagespeed optimizations, security hardening
+
+## Fork-only notes
+
+Fork maintains Arena/P2/Unipile/Facebook/Presentation integrations and mothership admin routes.

--- a/.upstream-sync/ledger/2026-08-06-2/release-notes.md
+++ b/.upstream-sync/ledger/2026-08-06-2/release-notes.md
@@ -1,0 +1,9 @@
+# Release Notes — 2026-08-06-2
+
+All upstream release notes from the last synced `main` SHA through the current sync (1 version).
+
+## v0.7.30
+
+_Released 2026-07-11 · commit `207785c8`_
+
+_Release v0.7.30 — no release body on GitHub; commit has no details._

--- a/.upstream-sync/ledger/2026-08-06-2/run.md
+++ b/.upstream-sync/ledger/2026-08-06-2/run.md
@@ -1,0 +1,11 @@
+# Upstream Sync Run — 2026-08-06-2
+
+## Sync topology
+
+- **Target branch:** `feat/github-merge-agent`
+- **Upstream HEAD:** `207785c8`
+- **Merge-base (target ↔ upstream):** `e2fecc86`
+- **Analysis baseline:** `6c3d11b2` (lastSyncedUpstreamSha)
+- **Commits in sync range:** 24
+- **Merge tip:** next-release v0.7.30 (`207785c8`; full upstream HEAD `e1ab24c1`)
+

--- a/.upstream-sync/ledger/2026-08-06-2/skipped.md
+++ b/.upstream-sync/ledger/2026-08-06-2/skipped.md
@@ -1,0 +1,5 @@
+# Skipped Upstream Changes — 2026-08-06-2
+
+Changes from simstudioai/sim we deliberately did not take during this sync.
+
+_No upstream changes skipped._

--- a/.upstream-sync/stack.json
+++ b/.upstream-sync/stack.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-08-06T11:22:06.905Z",
+  "updatedAt": "2026-08-06T11:22:14.269Z",
   "stack": [
     {
       "runId": "2026-08-06",
@@ -7,6 +7,14 @@
       "upstreamSha": "6c3d11b2df6c1c18490a27dab17b48d881045918",
       "branch": "upstream-sync/2026-08-05T10-46-19",
       "prNumber": 681,
+      "status": "open"
+    },
+    {
+      "runId": "2026-08-06-2",
+      "releaseVersion": "v0.7.30",
+      "upstreamSha": "207785c8e4a700b085ec317e433748c6e327ee2e",
+      "branch": "upstream-sync/2026-08-06T11-22-06",
+      "prNumber": 686,
       "status": "open"
     }
   ]

--- a/.upstream-sync/stack.json
+++ b/.upstream-sync/stack.json
@@ -1,0 +1,13 @@
+{
+  "updatedAt": "2026-08-06T11:22:06.905Z",
+  "stack": [
+    {
+      "runId": "2026-08-06",
+      "releaseVersion": null,
+      "upstreamSha": "6c3d11b2df6c1c18490a27dab17b48d881045918",
+      "branch": "upstream-sync/2026-08-05T10-46-19",
+      "prNumber": 681,
+      "status": "open"
+    }
+  ]
+}

--- a/.upstream-sync/state.json
+++ b/.upstream-sync/state.json
@@ -5,7 +5,7 @@
   "status": "running",
   "openQuestions": [],
   "activeBranch": "upstream-sync/2026-08-06T11-22-06",
-  "activePrNumber": 681,
+  "activePrNumber": 686,
   "activeMergeBase": "upstream-sync/2026-08-05T10-46-19",
   "activeUpstreamSha": "207785c8e4a700b085ec317e433748c6e327ee2e",
   "stack": [
@@ -15,6 +15,14 @@
       "upstreamSha": "6c3d11b2df6c1c18490a27dab17b48d881045918",
       "branch": "upstream-sync/2026-08-05T10-46-19",
       "prNumber": 681,
+      "status": "open"
+    },
+    {
+      "runId": "2026-08-06-2",
+      "releaseVersion": "v0.7.30",
+      "upstreamSha": "207785c8e4a700b085ec317e433748c6e327ee2e",
+      "branch": "upstream-sync/2026-08-06T11-22-06",
+      "prNumber": 686,
       "status": "open"
     }
   ]

--- a/.upstream-sync/state.json
+++ b/.upstream-sync/state.json
@@ -1,11 +1,21 @@
 {
   "lastSyncedUpstreamSha": "6c3d11b2df6c1c18490a27dab17b48d881045918",
   "lastSyncedAt": "2026-08-06T07:01:52.686Z",
-  "lastRunId": "2026-08-06",
-  "status": "completed",
+  "lastRunId": "2026-08-06-2",
+  "status": "running",
   "openQuestions": [],
-  "activeBranch": "upstream-sync/2026-08-05T10-46-19",
+  "activeBranch": "upstream-sync/2026-08-06T11-22-06",
   "activePrNumber": 681,
-  "activeMergeBase": "feat/github-merge-agent",
-  "activeUpstreamSha": null
+  "activeMergeBase": "upstream-sync/2026-08-05T10-46-19",
+  "activeUpstreamSha": "207785c8e4a700b085ec317e433748c6e327ee2e",
+  "stack": [
+    {
+      "runId": "2026-08-06",
+      "releaseVersion": null,
+      "upstreamSha": "6c3d11b2df6c1c18490a27dab17b48d881045918",
+      "branch": "upstream-sync/2026-08-05T10-46-19",
+      "prNumber": 681,
+      "status": "open"
+    }
+  ]
 }


### PR DESCRIPTION
Duplicate of #685 — opened because land-target tip pointers were still stuck on #681 after #685 completed. Closing so the stack tip remains #685.